### PR TITLE
Run Stream Support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<Version>0.5.3</Version>
+		<Version>0.6.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/PromptPlayground/Converters/NullToVisibilityConverter.cs
+++ b/PromptPlayground/Converters/NullToVisibilityConverter.cs
@@ -10,12 +10,12 @@ namespace PromptPlayground.Converters
 {
     public class NullToVisibilityConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             return value != null;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/PromptPlayground/Converters/StringToBooleanConverter.cs
+++ b/PromptPlayground/Converters/StringToBooleanConverter.cs
@@ -10,7 +10,7 @@ namespace PromptPlayground.Converters
 {
     public class StringToBooleanConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value == null || parameter == null || !(value is string) || !(parameter is string))
             {
@@ -23,7 +23,7 @@ namespace PromptPlayground.Converters
             return strValue.Equals(strParameter, StringComparison.OrdinalIgnoreCase);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotSupportedException();
         }

--- a/PromptPlayground/Messages/ConfigurationRequestMessage.cs
+++ b/PromptPlayground/Messages/ConfigurationRequestMessage.cs
@@ -7,7 +7,13 @@ using System.Threading.Tasks;
 
 namespace PromptPlayground.Messages
 {
-    public class ResultCountRequestMessage : RequestMessage<int>
+    public class ConfigurationRequestMessage : RequestMessage<string>
     {
+        public ConfigurationRequestMessage(string config)
+        {
+            Config = config;
+        }
+
+        public string Config { get; }
     }
 }

--- a/PromptPlayground/PromptPlayground.csproj
+++ b/PromptPlayground/PromptPlayground.csproj
@@ -9,9 +9,9 @@
 		<Platforms>AnyCPU;x64</Platforms>
 		<NoWarn>SKEXP0001;SKEXP0002;SKEXP0004;SKEXP0050</NoWarn>
 	</PropertyGroup>
-  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+	</PropertyGroup>
 
 
 	<ItemGroup>
@@ -33,7 +33,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="DashScope.SemanticKernel" Version="0.8.1" />
 		<PackageReference Include="Humanizer" Version="2.14.1" />
-		<PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.10.0" />
+		<!--<PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.10.0" />-->
 		<PackageReference Include="LLamaSharp.semantic-kernel" Version="0.10.0" />
 		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.4.0-alpha" />
 		<PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.0.1" />
@@ -47,8 +47,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="Views\PluginsView.axaml.cs">
-	    <DependentUpon>PluginsView.axaml</DependentUpon>
-	  </Compile>
+		<Compile Update="Views\PluginsView.axaml.cs">
+			<DependentUpon>PluginsView.axaml</DependentUpon>
+		</Compile>
 	</ItemGroup>
 </Project>

--- a/PromptPlayground/ViewModels/ConfigViewModel.cs
+++ b/PromptPlayground/ViewModels/ConfigViewModel.cs
@@ -17,147 +17,147 @@ using System.Text.Json.Serialization;
 namespace PromptPlayground.ViewModels;
 
 public partial class ConfigViewModel : ViewModelBase, IConfigAttributesProvider,
-                                        IRecipient<ConfigurationRequestMessage>,
-                                        IRecipient<RequestMessage<IConfigAttributesProvider>>
+										IRecipient<ConfigurationRequestMessage>,
+										IRecipient<RequestMessage<IConfigAttributesProvider>>
 {
-    private string[] RequiredAttributes =
+	private string[] RequiredAttributes =
    [
        #region LLM Config
        ConfigAttribute.AzureDeployment,
-       ConfigAttribute.AzureEndpoint,
-       ConfigAttribute.AzureSecret,
-       ConfigAttribute.BaiduClientId,
-       ConfigAttribute.BaiduSecret,
-       ConfigAttribute.BaiduModel,
-       ConfigAttribute.OpenAIApiKey,
-       ConfigAttribute.OpenAIModel,
-       ConfigAttribute.DashScopeApiKey,
-       ConfigAttribute.DashScopeModel,
-       ConfigAttribute.LlamaModelPath
+	   ConfigAttribute.AzureEndpoint,
+	   ConfigAttribute.AzureSecret,
+	   ConfigAttribute.BaiduClientId,
+	   ConfigAttribute.BaiduSecret,
+	   ConfigAttribute.BaiduModel,
+	   ConfigAttribute.OpenAIApiKey,
+	   ConfigAttribute.OpenAIModel,
+	   ConfigAttribute.DashScopeApiKey,
+	   ConfigAttribute.DashScopeModel,
+	   ConfigAttribute.LlamaModelPath
        #endregion
    ];
 
-    public List<ConfigAttribute> AllAttributes { get; set; } = [];
+	public List<ConfigAttribute> AllAttributes { get; set; } = [];
 
-    [ObservableProperty]
-    private int maxCount = 3;
+	[ObservableProperty]
+	private int maxCount = 3;
 
-    [ObservableProperty]
-    private bool runStream = false;
+	[ObservableProperty]
+	private bool runStream = false;
 
-    #region Model
-    private int modelSelectedIndex = 0;
-    private ProfileService<ConfigViewModel> _profile;
+	#region Model
+	private int modelSelectedIndex = 0;
+	private ProfileService<ConfigViewModel> _profile;
 
-    public int ModelSelectedIndex
-    {
-        get => modelSelectedIndex; set
-        {
-            if (modelSelectedIndex != value)
-            {
-                modelSelectedIndex = value;
-                OnPropertyChanged(nameof(ModelSelectedIndex));
-                OnPropertyChanged(nameof(SelectedModel));
-                OnPropertyChanged(nameof(ModelAttributes));
-                OnPropertyChanged(nameof(SelectedModel.Name));
-            }
-        }
-    }
+	public int ModelSelectedIndex
+	{
+		get => modelSelectedIndex; set
+		{
+			if (modelSelectedIndex != value)
+			{
+				modelSelectedIndex = value;
+				OnPropertyChanged(nameof(ModelSelectedIndex));
+				OnPropertyChanged(nameof(SelectedModel));
+				OnPropertyChanged(nameof(ModelAttributes));
+				OnPropertyChanged(nameof(SelectedModel.Name));
+			}
+		}
+	}
 
-    [JsonIgnore]
-    public List<string> ModelLists => LLMs.Select(_ => _.Name).ToList();
-    [JsonIgnore]
-    public IList<ConfigAttribute> ModelAttributes => SelectedModel.SelectAttributes(this.AllAttributes);
-    [JsonIgnore]
-    public ILLMConfigViewModel SelectedModel => LLMs[ModelSelectedIndex];
-    [JsonIgnore]
-    private readonly List<ILLMConfigViewModel> LLMs = [];
-    #endregion
+	[JsonIgnore]
+	public List<string> ModelLists => LLMs.Select(_ => _.Name).ToList();
+	[JsonIgnore]
+	public IList<ConfigAttribute> ModelAttributes => SelectedModel.SelectAttributes(this.AllAttributes);
+	[JsonIgnore]
+	public ILLMConfigViewModel SelectedModel => LLMs[ModelSelectedIndex];
+	[JsonIgnore]
+	private readonly List<ILLMConfigViewModel> LLMs = [];
+	#endregion
 
-    #region IConfigAttributesProvider
-    IList<ConfigAttribute> IConfigAttributesProvider.AllAttributes => this.AllAttributes;
-    public ILLMConfigViewModel GetLLM()
-    {
-        return this.SelectedModel;
-    }
-    #endregion
+	#region IConfigAttributesProvider
+	IList<ConfigAttribute> IConfigAttributesProvider.AllAttributes => this.AllAttributes;
+	public ILLMConfigViewModel GetLLM()
+	{
+		return this.SelectedModel;
+	}
+	#endregion
 
-    public ConfigViewModel(bool requireLoadConfig = false) : this()
-    {
-        if (requireLoadConfig)
-        {
-            WeakReferenceMessenger.Default.RegisterAll(this);
-            LoadConfigFromUserProfile();
-        }
-    }
+	public ConfigViewModel(bool requireLoadConfig = false) : this()
+	{
+		if (requireLoadConfig)
+		{
+			WeakReferenceMessenger.Default.RegisterAll(this);
+			LoadConfigFromUserProfile();
+		}
+	}
 
-    public ConfigViewModel()
-    {
-        this.AllAttributes = CheckAttributes(this.AllAttributes);
+	public ConfigViewModel()
+	{
+		this.AllAttributes = CheckAttributes(this.AllAttributes);
 
-        LLMs.Add(new AzureOpenAIConfigViewModel(this));
-        LLMs.Add(new BaiduConfigViewModel(this));
-        LLMs.Add(new OpenAIConfigViewModel(this));
-        LLMs.Add(new DashScopeConfigViewModel(this));
-        LLMs.Add(new LlamaSharpConfigViewModel(this));
+		LLMs.Add(new AzureOpenAIConfigViewModel(this));
+		LLMs.Add(new BaiduConfigViewModel(this));
+		LLMs.Add(new OpenAIConfigViewModel(this));
+		LLMs.Add(new DashScopeConfigViewModel(this));
+		// LLMs.Add(new LlamaSharpConfigViewModel(this));
 
-        this._profile = new ProfileService<ConfigViewModel>("user.config");
-    }
+		this._profile = new ProfileService<ConfigViewModel>("user.config");
+	}
 
-    private void LoadConfigFromUserProfile()
-    {
-        var vm = this._profile.Get();
-        if (vm != null)
-        {
-            this.AllAttributes = CheckAttributes(vm.AllAttributes);
+	private void LoadConfigFromUserProfile()
+	{
+		var vm = this._profile.Get();
+		if (vm != null)
+		{
+			this.AllAttributes = CheckAttributes(vm.AllAttributes);
 
-            this.MaxCount = vm.MaxCount;
-            this.RunStream = vm.RunStream;
-            this.ModelSelectedIndex = vm.ModelSelectedIndex;
-        }
-    }
-    private List<ConfigAttribute> CheckAttributes(List<ConfigAttribute> list)
-    {
-        foreach (var item in RequiredAttributes)
-        {
-            if (!list.Any(_ => _.Name == item))
-            {
-                list.Add(new ConfigAttribute(item));
-            }
-        }
-        return list;
-    }
+			this.MaxCount = vm.MaxCount;
+			this.RunStream = vm.RunStream;
+			this.ModelSelectedIndex = vm.ModelSelectedIndex;
+		}
+	}
+	private List<ConfigAttribute> CheckAttributes(List<ConfigAttribute> list)
+	{
+		foreach (var item in RequiredAttributes)
+		{
+			if (!list.Any(_ => _.Name == item))
+			{
+				list.Add(new ConfigAttribute(item));
+			}
+		}
+		return list;
+	}
 
-    private void SaveConfigToUserProfile()
-    {
-        this._profile.Save(this);
-    }
+	private void SaveConfigToUserProfile()
+	{
+		this._profile.Save(this);
+	}
 
-    public void SaveConfig()
-    {
-        SaveConfigToUserProfile();
-    }
+	public void SaveConfig()
+	{
+		SaveConfigToUserProfile();
+	}
 
-    public void ReloadConfig()
-    {
-        this.LoadConfigFromUserProfile();
-    }
+	public void ReloadConfig()
+	{
+		this.LoadConfigFromUserProfile();
+	}
 
-    public void Receive(RequestMessage<IConfigAttributesProvider> message)
-    {
-        message.Reply(this);
-    }
+	public void Receive(RequestMessage<IConfigAttributesProvider> message)
+	{
+		message.Reply(this);
+	}
 
-    public void Receive(ConfigurationRequestMessage request)
-    {
-        switch (request.Config)
-        {
-            case nameof(MaxCount):
-                request.Reply(this.MaxCount.ToString());
-                break;
-            case nameof(RunStream):
-                request.Reply(this.RunStream.ToString());
-                break;
-        }
-    }
+	public void Receive(ConfigurationRequestMessage request)
+	{
+		switch (request.Config)
+		{
+			case nameof(MaxCount):
+				request.Reply(this.MaxCount.ToString());
+				break;
+			case nameof(RunStream):
+				request.Reply(this.RunStream.ToString());
+				break;
+		}
+	}
 }

--- a/PromptPlayground/ViewModels/ConfigViewModel.cs
+++ b/PromptPlayground/ViewModels/ConfigViewModel.cs
@@ -17,7 +17,7 @@ using System.Text.Json.Serialization;
 namespace PromptPlayground.ViewModels;
 
 public partial class ConfigViewModel : ViewModelBase, IConfigAttributesProvider,
-                                        IRecipient<ResultCountRequestMessage>,
+                                        IRecipient<ConfigurationRequestMessage>,
                                         IRecipient<RequestMessage<IConfigAttributesProvider>>
 {
     private string[] RequiredAttributes =
@@ -41,6 +41,9 @@ public partial class ConfigViewModel : ViewModelBase, IConfigAttributesProvider,
 
     [ObservableProperty]
     private int maxCount = 3;
+
+    [ObservableProperty]
+    private bool runStream = false;
 
     #region Model
     private int modelSelectedIndex = 0;
@@ -109,6 +112,7 @@ public partial class ConfigViewModel : ViewModelBase, IConfigAttributesProvider,
             this.AllAttributes = CheckAttributes(vm.AllAttributes);
 
             this.MaxCount = vm.MaxCount;
+            this.RunStream = vm.RunStream;
             this.ModelSelectedIndex = vm.ModelSelectedIndex;
         }
     }
@@ -139,13 +143,21 @@ public partial class ConfigViewModel : ViewModelBase, IConfigAttributesProvider,
         this.LoadConfigFromUserProfile();
     }
 
-    public void Receive(ResultCountRequestMessage message)
-    {
-        message.Reply(this.MaxCount);
-    }
-
     public void Receive(RequestMessage<IConfigAttributesProvider> message)
     {
         message.Reply(this);
+    }
+
+    public void Receive(ConfigurationRequestMessage request)
+    {
+        switch (request.Config)
+        {
+            case nameof(MaxCount):
+                request.Reply(this.MaxCount.ToString());
+                break;
+            case nameof(RunStream):
+                request.Reply(this.RunStream.ToString());
+                break;
+        }
     }
 }

--- a/PromptPlayground/ViewModels/ConfigViewModels/ConfigAttribute.cs
+++ b/PromptPlayground/ViewModels/ConfigViewModels/ConfigAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using DashScope;
+using ERNIE_Bot.SDK;
 using Humanizer;
 using System;
 using System.Collections.Generic;
@@ -64,7 +65,7 @@ namespace PromptPlayground.ViewModels.ConfigViewModels
 
         public const string BaiduClientId = nameof(BaiduClientId);
         public const string BaiduSecret = nameof(BaiduSecret);
-        [ConfigType("select", "Ernie-Bot", "Ernie-Bot-turbo", "BLOOMZ_7B")]
+        [ConfigType("select", "Ernie-Bot", "Ernie-Bot-turbo", "Ernie-Bot-4", "Ernie-Bot 8k", "Ernie-Bot-speed", "BLOOMZ_7B")]
         public const string BaiduModel = nameof(BaiduModel);
 
         public const string OpenAIApiKey = nameof(OpenAIApiKey);

--- a/PromptPlayground/ViewModels/ConfigViewModels/LLM/BaiduConfigViewModel.cs
+++ b/PromptPlayground/ViewModels/ConfigViewModels/LLM/BaiduConfigViewModel.cs
@@ -39,6 +39,9 @@ namespace PromptPlayground.ViewModels.ConfigViewModels.LLM
             {
                 "BLOOMZ_7B" => ModelEndpoints.BLOOMZ_7B,
                 "Ernie-Bot-turbo" => ModelEndpoints.ERNIE_Bot_Turbo,
+                "Ernie-Bot-4" => ModelEndpoints.ERNIE_Bot_4,
+                "Ernie-Bot 8k" => ModelEndpoints.ERNIE_Bot_8K,
+                "Ernie-Bot-speed" => ModelEndpoints.ERNIE_Bot_Speed,
                 _ => ModelEndpoints.ERNIE_Bot
             };
     }

--- a/PromptPlayground/ViewModels/GenerateResult.cs
+++ b/PromptPlayground/ViewModels/GenerateResult.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using PromptPlayground.ViewModels;
 using System;
+using System.Collections.Generic;
 
 namespace PromptPlayground.Services
 {
@@ -25,7 +26,7 @@ namespace PromptPlayground.Services
         private string text = string.Empty;
 
         [ObservableProperty]
-        private TimeSpan elapsed;
+        private TimeSpan? elapsed;
 
         [ObservableProperty]
         private string? error;

--- a/PromptPlayground/Views/ConfigWindow.axaml
+++ b/PromptPlayground/Views/ConfigWindow.axaml
@@ -30,6 +30,10 @@
 				</Style>
 			</StackPanel.Styles>
 			<Grid ColumnDefinitions="80,4*" Margin="10,3" MinWidth="420">
+				<TextBlock Text="流式输出" Grid.Column="0"/>
+				<CheckBox IsChecked="{Binding RunStream}" Grid.Column="1"></CheckBox>
+			</Grid>
+			<Grid ColumnDefinitions="80,4*" Margin="10,3" MinWidth="420">
 				<TextBlock Text="生成数量" Grid.Column="0"/>
 				<NumericUpDown Value="{Binding MaxCount}" FormatString="0" Maximum="100" Minimum="1" Grid.Column="1" />
 			</Grid>

--- a/PromptPlayground/Views/ResultsView.axaml
+++ b/PromptPlayground/Views/ResultsView.axaml
@@ -39,7 +39,8 @@
 									<ScrollViewer IsVisible="{Binding !HasError}">
 										<Grid>
 											<WrapPanel Grid.Row="0" VerticalAlignment="Bottom" HorizontalAlignment="Right">
-												<Label Classes="Ghost Blue" Theme="{StaticResource TagLabel}">
+												<Label Classes="Ghost Blue" Theme="{StaticResource TagLabel}"
+													   IsVisible="{Binding TokenUsage,Converter={StaticResource NullToVisibilityConverter }}">
 													<Label.Content>
 														<WrapPanel>
 															<TextBlock Text="{Binding TokenUsage.Total}"/>
@@ -50,11 +51,12 @@
 														</WrapPanel>
 													</Label.Content>
 												</Label>
-												<Label Classes="Ghost Green" Theme="{StaticResource TagLabel}">
+												<Label Classes="Ghost Green" Theme="{StaticResource TagLabel}"
+													    IsVisible="{Binding Elapsed,Converter={StaticResource NullToVisibilityConverter }}" >
 													<Label.Content>
 														<WrapPanel>
 															<i:Icon Value="mdi-clock-time-four-outline"/>
-															<TextBlock Text="{Binding Elapsed.TotalSeconds,StringFormat={}{0:0.000}s}"/>
+															<TextBlock Text="{Binding Elapsed.Value.TotalSeconds,StringFormat={}{0:0.000}s}"/>
 														</WrapPanel>
 													</Label.Content>
 												</Label>


### PR DESCRIPTION
🎨 Update ConfigWindow.axaml and ResultsView.axaml
- Added a checkbox for the "RunStream" configuration option in ConfigWindow.axaml.
- Updated the visibility of the TokenUsage and Elapsed labels in ResultsView.axaml.

🔧 Refactor converters and messages, add new service method

Refactor converters and messages to use nullable reference types. Add new method `RunStreamAsync` to the `PromptService` class for running prompts asynchronously.

🔧 Update ConfigAttribute and BaiduConfigViewModel

- Added new options to the ConfigType attribute in ConfigAttribute.cs.
- Added new model endpoints in BaiduConfigViewModel.cs.

🐛 Fix GenerateResult and SemanticFunctionViewModel

- Changed the elapsed property in GenerateResult.cs to be nullable.
- Added a new configuration option for running the stream in SemanticFunctionViewModel.cs.

🔧 Fix binding issue in ResultsView.axaml

- Update binding expression for Elapsed property in ResultsView.axaml to use Elapsed.Value.TotalSeconds instead of Elapsed.TotalSeconds.

This change fixes a bug where the Elapsed property was not correctly displayed in the ResultsView. The binding expression has been updated to use the Value property of the Elapsed object, ensuring that the correct value is displayed.